### PR TITLE
Add DiagnosedPublisher to the ImuPublisher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   geometry_msgs
   sensor_msgs
+  diagnostic_updater
 )
 
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Changes done with respect to the orginal source:
  - Adapted CMakelists.txt to also install TARGETS
  - Adapted CMakelists.txt to run a PRE-BUILD command that builds libraries needed for the executable
  - Removed all trailing whitespaces
+ - Added DiagnosedPublisher to the ImuPublisher
 
 # Documentation:
   For this you need the full MT SDK which can be downloaded from: https://www.xsens.com/software-downloads

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>diagnostic_updater</depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>


### PR DESCRIPTION
With this patch diagnostics are added for published imu messages.

Would this be maintainable over the long run? I'm going to mail this patch idea to xsens so hopefully it will be included in future releases.