### PR TITLE
no longer need to support pre-c++11 build systems, let newer systems use a newer C++ standard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: kinetic, ROS_REPO: main}
-          - {ROS_DISTRO: melodic, ROS_REPO: main}
           - {ROS_DISTRO: noetic, ROS_REPO: main}
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(xsens_mti_driver)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages


### PR DESCRIPTION
I assume this is the case, otherwise if statements are needed in the cmake to build in later systems using c++17 or simi/lar, for instance with c++11 building on Ubuntu 22.04 results in errors like this:

```
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
```